### PR TITLE
Fix build on macOS

### DIFF
--- a/build.py
+++ b/build.py
@@ -1,5 +1,29 @@
 # -*- coding: utf-8 -*-
 import PyInstaller.__main__
+import platform
+
+# fun hacks for pyexiv2 on macOS
+# see https://github.com/pyinstaller/pyinstaller/discussions/6404
+if platform.system() == "Darwin":
+    import fileinput
+    import pyexiv2
+    import os
+    import os.path
+
+    pyexiv2_path = pyexiv2.__path__[0]
+    libexiv2_dylib_original_path = os.path.join(pyexiv2_path, "lib", "libexiv2.dylib")
+    libexiv2_dylib_path = os.path.join(pyexiv2_path, "lib", "libexiv2.27.dylib")
+
+    if os.path.exists(libexiv2_dylib_original_path):
+        os.rename(libexiv2_dylib_original_path, libexiv2_dylib_path)
+
+    with fileinput.input(
+            os.path.join(pyexiv2_path, "lib", "__init__.py"),
+            inplace=True
+            ) as f:
+        for line in f:
+            print(line.replace("libexiv2.dylib", "libexiv2.27.dylib"))
+
 
 PyInstaller.__main__.run(
     [
@@ -7,6 +31,8 @@ PyInstaller.__main__.run(
         "--clean",
         "--onefile",
         "--console",
+        "--additional-hooks-dir",
+        "extra-hooks/",
         "--collect-all",
         "pyexiv2",
         "--name",

--- a/extra-hooks/hook-pyexiv2.py
+++ b/extra-hooks/hook-pyexiv2.py
@@ -1,0 +1,16 @@
+import os
+import glob
+
+from PyInstaller import compat
+from PyInstaller.utils.hooks import get_package_paths
+
+if compat.is_darwin:
+    binaries = []
+    datas = []
+    package_root_base, package_root = get_package_paths('pyexiv2')
+
+    # libs = glob.glob(os.path.join(package_root, 'lib', 'py3.*-darwin', '*.so'))
+    # binaries += [(lib, '.') for lib in libs]
+
+    libs = glob.glob(os.path.join(package_root, 'lib', '*.dylib'))
+    binaries += [(lib, '.') for lib in libs]

--- a/tests/test_ffmpeg.py
+++ b/tests/test_ffmpeg.py
@@ -1,33 +1,20 @@
 # -*- coding: utf-8 -*-
-import pytest
 import os
-import sys
 from iscc import bin
-
-
-def is_linux():
-    return sys.platform == "linux"
-
-
-def is_py36():
-    return sys.version.startswith("3.6")
 
 
 def test_exe_path():
     assert "ffmpeg" in bin.ffmpeg_bin()
 
 
-@pytest.mark.skipif(is_linux() and is_py36(), reason="custom ffmpeg")
 def test_ffmpeg_exists():
     assert os.path.exists(bin.ffmpeg_bin())
 
 
-@pytest.mark.skipif(is_linux() and is_py36(), reason="custom ffmpeg")
 def test_ffmpeg_executable():
     assert os.access(bin.ffmpeg_bin(), os.X_OK)
 
 
-@pytest.mark.skipif(is_linux() and is_py36(), reason="custom ffmpeg")
 def test_get_version_info():
     vi = bin.ffmpeg_version_info()
     assert vi.startswith("4.2")


### PR DESCRIPTION
The compiled Python module of pyexiv2 is dynamically linked to the
libexiv2.27.dylib and bundles this library as libexiv2.dylib.

pyexiv2 loads this dylib dynamically in its __init__.py, but this seems
to stop working when packaging iscc-cli with PyInstaller.

Based on help from the PyInstaller maintainers, the build script now
does some fun hacks in the pyexiv2 site-packages to clean this up and
produce a working executable.

See: pyinstaller/pyinstaller#6404